### PR TITLE
Mount a volume to save the logs to the VM

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
               export DOCKER_MACHINE_NAME=${DOCKER_AWS_MANAGER_NAME}
               scp -o StrictHostKeyChecking=no ubuntu@${DOCKER_AWS_MANAGER_IP}:/home/ubuntu/DEPLOY_SSL_* ~/qliktive-custom-analytics/secrets/
               cd ..
-              ACCEPT_EULA=yes AUTH_STRATEGY="github" docker-compose -f docker-compose.yml -f docker-compose.pregen-ssl.yml config > docker-compose.merged.yml
+              ACCEPT_EULA=yes AUTH_STRATEGY="github" docker-compose -f docker-compose.yml -f dicjer.cinoise,circleci.yml -f docker-compose.pregen-ssl.yml config > docker-compose.merged.yml
               \cp docker-compose.merged.yml docker-compose.yml
 
               # Check if configs was changed. If so we need to remove stack before deploying to force an update.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
               export DOCKER_MACHINE_NAME=${DOCKER_AWS_MANAGER_NAME}
               scp -o StrictHostKeyChecking=no ubuntu@${DOCKER_AWS_MANAGER_IP}:/home/ubuntu/DEPLOY_SSL_* ~/qliktive-custom-analytics/secrets/
               cd ..
-              ACCEPT_EULA=yes AUTH_STRATEGY="github" docker-compose -f docker-compose.yml -f dicjer.cinoise,circleci.yml -f docker-compose.pregen-ssl.yml config > docker-compose.merged.yml
+              ACCEPT_EULA=yes AUTH_STRATEGY="github" docker-compose -f docker-compose.yml -f docker-compose.circleci.yml -f docker-compose.pregen-ssl.yml config > docker-compose.merged.yml
               \cp docker-compose.merged.yml docker-compose.yml
 
               # Check if configs was changed. If so we need to remove stack before deploying to force an update.

--- a/docker-compose.circleci.yml
+++ b/docker-compose.circleci.yml
@@ -1,0 +1,8 @@
+version: "3.3"
+
+# This file is for parts that are specific for our own deployment on ap.qlikcore.com
+
+services:
+  elasticsearch:
+    volumes:
+      - /esdatadir:/usr/share/elasticsearch/data:rw

--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -17,6 +17,8 @@ services:
     # This service only runs as one instance in our stack and is
     # used by Kibana (consuming) and Logstash (storing).
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.1.1
+    volumes:
+      - /esdatadir:/usr/share/elasticsearch/data:rw
     environment:
       ES_JAVA_OPTS: "-Xmx512m -Xms512m"
     deploy:

--- a/docker-compose.logging.yml
+++ b/docker-compose.logging.yml
@@ -17,8 +17,6 @@ services:
     # This service only runs as one instance in our stack and is
     # used by Kibana (consuming) and Logstash (storing).
     image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.1.1
-    volumes:
-      - /esdatadir:/usr/share/elasticsearch/data:rw
     environment:
       ES_JAVA_OPTS: "-Xmx512m -Xms512m"
     deploy:


### PR DESCRIPTION
We are now mounting a volume on the elasticsearch container to the VM node so the logs should be saved until the VMs are removed.

the folder on the VM is `/esdatadir`

created like this:

```
mkdir esdatadir
chmod g+rwx esdatadir
chgrp 1000 esdatadir
```

If the host does not have this folder E.G you spinning up the example on your machine(s) the folder will be created.
