### PR TITLE
Increasing memory limit for alerting

### DIFF
--- a/configs/prometheus/alert.rules
+++ b/configs/prometheus/alert.rules
@@ -62,7 +62,7 @@ ALERT high_cpu_usage_on_container
   }
 
 ALERT container_eating_memory
-  IF sum(container_memory_rss{container_label_com_docker_swarm_task_name=~".+"}) by (container_label_com_docker_swarm_task_name,container_label_com_docker_swarm_node_id) > 3000000000
+  IF sum(container_memory_rss{container_label_com_docker_swarm_task_name=~".+"}) by (container_label_com_docker_swarm_task_name,container_label_com_docker_swarm_node_id) > 12884901888
   FOR 5m
   ANNOTATIONS {
       summary = "HIGH MEMORY USAGE WARNING: TASK '{{ $labels.container_label_com_docker_swarm_task_name }}' on '{{ $labels.container_label_com_docker_swarm_node_id }}'",


### PR DESCRIPTION
To fix our alerting issue. Set to 75% of memory, above the lower workingset. 

Issue created to handle deployment specific alerting rules in #341 
